### PR TITLE
merge maj2_random floating point hash function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -102,3 +102,6 @@ if (OPENGL_EXAMPLES)
         endif ()
     endforeach(prog)
 endif (OPENGL_EXAMPLES)
+
+add_executable(test_maj src/test_maj.c)
+target_link_libraries(test_maj m)

--- a/shaders/cube.frag
+++ b/shaders/cube.frag
@@ -1,3 +1,13 @@
+/*
+ * maj2_random
+ *
+ * maj2_random is a simplified floating point hash function derived from SHA-2,
+ * retaining its high quality entropy compression function modified to permute
+ * entropy from a vec2 (designed for UV coordinates) returning float values
+ * between 0.0 and 1.0. since maj2_random is a hash function it will return
+ * coherent noise. vector argument can be truncated prior to increase grain.
+ */
+
 #version 450
 
 layout (location = 0) in vec3 v_normal;
@@ -8,29 +18,53 @@ layout (location = 4) in vec3 v_lightDir;
 
 layout (location = 0) out vec4 outFragColor;
 
+#define NROUNDS 2
+
+/* first 8 rounds of the SHA-256 k constant */
+uint sha256_k[8] = uint[]
+(
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
+    0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u
+);
+
 uint ror(uint x, int d) { return (x >> d) | (x << (32-d)); }
 uint sigma0(uint h1) { return ror(h1, 2) ^ ror(h1, 13) ^ ror(h1, 22); }
 uint sigma1(uint h4) { return ror(h4, 6) ^ ror(h4, 11) ^ ror(h4, 25); }
 uint ch(uint x, uint y, uint z) { return z ^ (x & (y ^ z)); }
 uint maj(uint x, uint y, uint z) { return (x & y) ^ ((x ^ y) & z); }
+uint gamma0(uint a) { return ror(a, 7) ^ ror(a, 18) ^ (a >> 3); }
+uint gamma1(uint b) { return ror(b, 17) ^ ror(b, 19) ^ (b >> 10); }
 
-float random(vec2 v)
+vec2 unorm(uvec2 n) { return uvec2(n & uvec2((1u<<23)-1u)) / vec2((1u<<23)-1u); }
+vec2 trunc(vec2 uv, float d) { return floor(uv / d) * d; }
+
+vec2 maj2_random(vec2 uv)
 {
     uint H[8] = uint[] ( 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u );
     uint W[2];
     uint T0,T1;
     int i;
 
-    uint x = uint(abs(v.x) * float(1u<<24));
-    uint y = uint(abs(v.y) * float(1u<<24));
-    x = x - x % (1u<<16);
-    y = y - y % (1u<<16);
+    /*
+     * extract 48-bits of entropy from mantissas to create truncated
+     * two word initialization vector 'W' composed using the 48-bits
+     * of 'uv' entropy rotated and copied to keep the field equalized.
+     * exponent is ignored as the inputs are normalized 'uv' values.
+     */
+    vec2 s = sign(uv); /* note: we don't have frexp in early GLSL */
+    uint x = uint(abs(uv.x) * float(1u<<23)) | (uint(s.x < 0) << 23);
+    uint y = uint(abs(uv.y) * float(1u<<23)) | (uint(s.y < 0) << 23);
 
     W[0] = x | (y << 24);
     W[1] = (y >> 8) | (x << 16);
 
-    for (i=0; i<8; i++) {
-        T0 = W[i&1] + H[7] + sigma1(H[4]) + ch(H[4], H[5], H[6]);
+    for (i=0; i<NROUNDS; i++) {
+        W[i] = gamma1(W[(i-2)&1]) + W[(i-7)&1] + gamma0(W[(i-15)&1]) + W[(i-16)&1];
+    }
+
+    /* we use N=2 rounds instead of 64 and alternate 2 words of iv in W */
+    for (i=0; i<NROUNDS; i++) {
+        T0 = W[i&1] + H[7] + sigma1(H[4]) + ch(H[4], H[5], H[6]) + sha256_k[i];
         T1 = maj(H[0], H[1], H[2]) + sigma0(H[0]);
         H[7] = H[6];
         H[6] = H[5];
@@ -42,19 +76,18 @@ float random(vec2 v)
         H[0] = T0 + T1;
     }
 
-    uint r = 0u;
-    for (i = 0; i < 8; i++) {
-        r ^= H[i];
-    }
-
-    return float(r&((1u<<24)-1u)) / float(1u<<24);
+    return unorm(uvec2(H[0] ^ H[1] ^ H[2] ^ H[3],
+                       H[4] ^ H[5] ^ H[6] ^ H[7]));
 }
 
 void main()
 {
+  // uncomment for temporal surface stability i.e. increase grain
+  //float r = maj2_random(trunc(v_uv, 0.1)).x * 0.5;
+  float r = maj2_random(v_uv).x * 0.5;
+
   float ambient = 0.1;
   float diff = max(dot(v_normal, v_lightDir), 0.0);
-  float r = random(v_uv) * 0.1;
   vec4 finalColor = (ambient + diff + r) * v_color;
   outFragColor = vec4(finalColor.rgb, v_color.a);
 }

--- a/shaders/cube.fsh
+++ b/shaders/cube.fsh
@@ -1,3 +1,13 @@
+/*
+ * maj2_random
+ *
+ * maj2_random is a simplified floating point hash function derived from SHA-2,
+ * retaining its high quality entropy compression function modified to permute
+ * entropy from a vec2 (designed for UV coordinates) returning float values
+ * between 0.0 and 1.0. since maj2_random is a hash function it will return
+ * coherent noise. vector argument can be truncated prior to increase grain.
+ */
+
 #version 150
 
 in vec3 v_normal;
@@ -8,29 +18,53 @@ in vec3 v_lightDir;
 
 out vec4 outFragColor;
 
+#define NROUNDS 2
+
+/* first 8 rounds of the SHA-256 k constant */
+uint sha256_k[8] = uint[]
+(
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
+    0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u
+);
+
 uint ror(uint x, int d) { return (x >> d) | (x << (32-d)); }
 uint sigma0(uint h1) { return ror(h1, 2) ^ ror(h1, 13) ^ ror(h1, 22); }
 uint sigma1(uint h4) { return ror(h4, 6) ^ ror(h4, 11) ^ ror(h4, 25); }
 uint ch(uint x, uint y, uint z) { return z ^ (x & (y ^ z)); }
 uint maj(uint x, uint y, uint z) { return (x & y) ^ ((x ^ y) & z); }
+uint gamma0(uint a) { return ror(a, 7) ^ ror(a, 18) ^ (a >> 3); }
+uint gamma1(uint b) { return ror(b, 17) ^ ror(b, 19) ^ (b >> 10); }
 
-float random(vec2 v)
+vec2 unorm(uvec2 n) { return uvec2(n & uvec2((1u<<23)-1u)) / vec2((1u<<23)-1u); }
+vec2 trunc(vec2 uv, float d) { return floor(uv / d) * d; }
+
+vec2 maj2_random(vec2 uv)
 {
     uint H[8] = uint[] ( 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u );
     uint W[2];
     uint T0,T1;
     int i;
 
-    uint x = uint(abs(v.x) * float(1u<<24));
-    uint y = uint(abs(v.y) * float(1u<<24));
-    x = x - x % (1u<<16);
-    y = y - y % (1u<<16);
+    /*
+     * extract 48-bits of entropy from mantissas to create truncated
+     * two word initialization vector 'W' composed using the 48-bits
+     * of 'uv' entropy rotated and copied to keep the field equalized.
+     * exponent is ignored as the inputs are normalized 'uv' values.
+     */
+    vec2 s = sign(uv); /* note: we don't have frexp in early GLSL */
+    uint x = uint(abs(uv.x) * float(1u<<23)) | (uint(s.x < 0) << 23);
+    uint y = uint(abs(uv.y) * float(1u<<23)) | (uint(s.y < 0) << 23);
 
     W[0] = x | (y << 24);
     W[1] = (y >> 8) | (x << 16);
 
-    for (i=0; i<8; i++) {
-        T0 = W[i&1] + H[7] + sigma1(H[4]) + ch(H[4], H[5], H[6]);
+    for (i=0; i<NROUNDS; i++) {
+        W[i] = gamma1(W[(i-2)&1]) + W[(i-7)&1] + gamma0(W[(i-15)&1]) + W[(i-16)&1];
+    }
+
+    /* we use N=2 rounds instead of 64 and alternate 2 words of iv in W */
+    for (i=0; i<NROUNDS; i++) {
+        T0 = W[i&1] + H[7] + sigma1(H[4]) + ch(H[4], H[5], H[6]) + sha256_k[i];
         T1 = maj(H[0], H[1], H[2]) + sigma0(H[0]);
         H[7] = H[6];
         H[6] = H[5];
@@ -42,19 +76,18 @@ float random(vec2 v)
         H[0] = T0 + T1;
     }
 
-    uint r = 0u;
-    for (i = 0; i < 8; i++) {
-        r ^= H[i];
-    }
-
-    return float(r&((1u<<24)-1u)) / float(1u<<24);
+    return unorm(uvec2(H[0] ^ H[1] ^ H[2] ^ H[3],
+                       H[4] ^ H[5] ^ H[6] ^ H[7]));
 }
 
 void main()
 {
+  // uncomment for temporal surface stability i.e. increase grain
+  //float r = maj2_random(trunc(v_uv, 0.1)).x * 0.5;
+  float r = maj2_random(v_uv).x * 0.5;
+
   float ambient = 0.1;
   float diff = max(dot(v_normal, v_lightDir), 0.0);
-  float r = random(v_uv) * 0.1;
   vec4 finalColor = (ambient + diff + r) * v_color;
   outFragColor = vec4(finalColor.rgb, v_color.a);
 }

--- a/src/maj2_random.h
+++ b/src/maj2_random.h
@@ -1,0 +1,91 @@
+#pragma once
+
+#include <math.h>
+typedef unsigned uint;
+typedef __attribute__((vector_size(8))) float vec2;
+typedef __attribute__((vector_size(8))) uint uvec2;
+
+/*
+ * maj2_random
+ *
+ * maj2_random is a simplified floating point hash function derived from SHA-2,
+ * retaining its high quality entropy compression function modified to permute
+ * entropy from a vec2 (designed for UV coordinates) returning float values
+ * between 0.0 and 1.0. since maj2_random is a hash function it will return
+ * coherent noise. vector argument can be truncated prior to increase grain.
+ *
+ * converted to Clang/GCC vectors
+ *
+ * compile: cc -O3 -march=skylake-avx512 -c maj2_random.c -o maj2_random.o
+ */
+
+/* first 8 rounds of the SHA-256 k constant */
+static uint sha256_k[8] =
+{
+    0x428a2f98u, 0x71374491u, 0xb5c0fbcfu, 0xe9b5dba5u,
+    0x3956c25bu, 0x59f111f1u, 0x923f82a4u, 0xab1c5ed5u
+};
+
+static uint ror(uint x, int d) { return (x >> d) | (x << (32-d)); }
+static uint sigma0(uint h1) { return ror(h1, 2) ^ ror(h1, 13) ^ ror(h1, 22); }
+static uint sigma1(uint h4) { return ror(h4, 6) ^ ror(h4, 11) ^ ror(h4, 25); }
+static uint ch(uint x, uint y, uint z) { return z ^ (x & (y ^ z)); }
+static uint maj(uint x, uint y, uint z) { return (x & y) ^ ((x ^ y) & z); }
+static uint gamma0(uint a) { return ror(a, 7) ^ ror(a, 18) ^ (a >> 3); }
+static uint gamma1(uint b) { return ror(b, 17) ^ ror(b, 19) ^ (b >> 10); }
+
+static vec2 unorm(uvec2 n) {
+    return (vec2) { n[0] & ((1u<<23)-1u), n[1] & ((1u<<23)-1u) }
+         / (vec2) { (1u<<23)-1u, (1u<<23)-1u };
+}
+static vec2 truncx(vec2 uv, float d) {
+    return (vec2){ (float)uv[0] / d, (float)uv[1] / d } * (vec2) { d , d };
+}
+static uvec2 sign(vec2 v) {
+    return (uvec2) { v[0] < 0.0f, v[1] < 0.0f };
+}
+
+static vec2 maj_random(vec2 uv, uint NROUNDS)
+{
+    uint H[8] = { 0u, 0u, 0u, 0u, 0u, 0u, 0u, 0u };
+    uint W[2];
+    uint T0,T1;
+    int i;
+
+    /*
+     * extract 48-bits of entropy from mantissas to create truncated
+     * two word initialization vector 'W' composed using the 48-bits
+     * of 'uv' entropy rotated and copied to keep the field equalized.
+     * exponent is ignored as the inputs are normalized 'uv' values.
+     */
+    uvec2 s = sign(uv); /* note: we don't have frexp in early GLSL */
+    uint x = (uint)(fabsf(uv[0]) * (float)(1u<<23)) | (s[0] << 23);
+    uint y = (uint)(fabsf(uv[1]) * (float)(1u<<23)) | (s[1] << 23);
+
+    W[0] = x | (y << 24);
+    W[1] = (y >> 8) | (x << 16);
+
+    for (i=0; i<NROUNDS; i++) {
+        W[i] = gamma1(W[(i-2)&1]) + W[(i-7)&1] + gamma0(W[(i-15)&1]) + W[(i-16)&1];
+    }
+
+    /* we use N rounds instead of 64 and alternate 2 words of iv in W */
+    for (i=0; i<NROUNDS; i++) {
+        T0 = W[i&1] + H[7] + sigma1(H[4]) + ch(H[4], H[5], H[6]) + sha256_k[i];
+        T1 = maj(H[0], H[1], H[2]) + sigma0(H[0]);
+        H[7] = H[6];
+        H[6] = H[5];
+        H[5] = H[4];
+        H[4] = H[3] + T0;
+        H[3] = H[2];
+        H[2] = H[1];
+        H[1] = H[0];
+        H[0] = T0 + T1;
+    }
+
+    return unorm((uvec2){H[0] ^ H[1] ^ H[2] ^ H[3],
+                         H[4] ^ H[5] ^ H[6] ^ H[7]});
+}
+
+static vec2 maj2_random(vec2 uv) { return maj_random(uv, 2); }
+static vec2 maj8_random(vec2 uv) { return maj_random(uv, 8); }

--- a/src/test_maj.c
+++ b/src/test_maj.c
@@ -1,0 +1,116 @@
+#undef NDEBUG
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+
+#include "maj2_random.h"
+
+typedef unsigned long long ullong;
+
+void sncatprintf(char *buf, size_t buflen, const char* fmt, int64_t n)
+{
+    size_t len = strlen(buf);
+    snprintf(buf+len, buflen-len, fmt, n);
+}
+
+char* format_comma(int64_t n)
+{
+    static char buf[65];
+
+    buf[0] = 0;
+    int n2 = 0;
+    int scale = 1;
+    if (n < 0) {
+        buf[0] = '-';
+        buf[1] = 0;
+        n = -n;
+    }
+    while (n >= 1000) {
+        n2 = n2 + scale * (n % 1000);
+        n /= 1000;
+        scale *= 1000;
+    }
+    sncatprintf(buf, sizeof(buf), "%d", n);
+    while (scale != 1) {
+        scale /= 1000;
+        n = n2 / scale;
+        n2 = n2  % scale;
+        sncatprintf(buf, sizeof(buf), ",%03d", n);
+    }
+    return buf;
+}
+
+char* format_rate(double rate)
+{
+    static char buf[65];
+    char unit = ' ';
+    double divisor = 1;
+    if (rate > 1e9) {
+        divisor = 1e9; unit = 'G';
+    } else if (rate > 1e6) {
+        divisor = 1e6; unit = 'M';
+    } else if (rate > 1e6) {
+        divisor = 1e3; unit = 'K';
+    }
+    snprintf(buf, sizeof(buf), "%.1f %c", rate / divisor, unit);
+    return buf;
+}
+
+vec2 f1(ullong i, ullong j) { return (vec2){ 0.0f, (float)i / (float)j }; }
+vec2 f2(ullong i, ullong j) { return (vec2){ (float)i / (float)j, 0.0f }; }
+vec2 f3(ullong i, ullong j) { return (vec2){ (float)i / (float)j, (float)i / (float)j }; }
+
+void test_maj(const char* name, int NROUNDS, ullong count, ullong range, vec2(*f)(ullong,ullong))
+{
+    vec2 sum = { 0.f, 0.f };
+    vec2 var = { 0.f, 0.f };
+    int debug = 0;
+
+    fflush(stdout);
+    for (ullong i = 0; i < count; i++) {
+        vec2 p = f(i, range);
+        vec2 q = maj_random(p, NROUNDS);
+        sum += q;
+        var += (vec2) { (q[0]-.5f)*(q[0]-.5f), (q[1]-.5f)*(q[1]-.5f) };
+    }
+
+    printf("%-32s%12s%12.5f%12.5f%12.5f%12.5f%12.5f%12.5f\n",
+        name, format_comma(count), sum[0]/count, sum[1]/count,
+        var[0]/count, var[1]/count, sqrt(var[0]/count), sqrt(var[1]/count));
+}
+
+void test_header(const char *name)
+{
+    printf("%-32s%12s%12s%12s%12s%12s%12s%12s\n",
+        name, "count", "mean(x)", "mean(y)",
+        "variance(x)", "variance(y)",
+        "std-dev(x)", "std-dev(y)");
+}
+
+void run_all_tests(int NROUNDS, ullong i, ullong j)
+{
+    char name[32];
+    snprintf(name, sizeof(name), "maj_random (NROUNDS=%d)", NROUNDS);
+    printf("\n");
+    test_header(name);
+    test_maj("(             0, (0 - 1M)/8M )", NROUNDS, i, j, f1);
+    test_maj("(             0, (0 - 8M)/8M )", NROUNDS, j, j, f1);
+    test_maj("( (0 - 1M)/8M ),           0 )", NROUNDS, i, j, f2);
+    test_maj("( (0 - 8M)/8M ),           0 )", NROUNDS, j, j, f2);
+    test_maj("( (0 - 1M)/8M ), (0 - 1M)/8M )", NROUNDS, i, j, f3);
+    test_maj("( (0 - 8M)/8M ), (0 - 8M)/8M )", NROUNDS, j, j, f3);
+    printf("\n");
+}
+
+int main(int argc, char **argv)
+{
+    ullong i = argc >= 2 ? atoi(argv[1]) : 1000000;
+    ullong j = argc >= 3 ? atoi(argv[2]) : 8000000;
+    run_all_tests(2, i, j);
+    run_all_tests(4, i, j);
+    run_all_tests(6, i, j);
+    run_all_tests(8, i, j);
+    return 0;
+}


### PR DESCRIPTION
maj2_random is a simplified floating-point hash function derived from SHA-2, retaining its high-quality entropy compression function modified to permute entropy from a vec2 (designed for UV coordinates) returning float values between 0.0 and 1.0. since maj2_random is a hash function it will return coherent noise. vector argument can be truncated prior to increase grain.
